### PR TITLE
Adds right curl flag in example

### DIFF
--- a/specs/2.0/PaymentService-V25.yaml
+++ b/specs/2.0/PaymentService-V25.yaml
@@ -12,7 +12,7 @@ info:
 
     ```
     curl
-    -U "ws@Company.YourCompany":"YourWsPassword" \
+    -u "ws@Company.YourCompany":"YourWsPassword" \
     -H "Content-Type: application/json" \
     ...
     ```

--- a/specs/2.0/PaymentService-V30.yaml
+++ b/specs/2.0/PaymentService-V30.yaml
@@ -12,7 +12,7 @@ info:
 
     ```
     curl
-    -U "ws@Company.YourCompany":"YourWsPassword" \
+    -u "ws@Company.YourCompany":"YourWsPassword" \
     -H "Content-Type: application/json" \
     ...
     ```

--- a/specs/3.0/AccountService-v3.yaml
+++ b/specs/3.0/AccountService-v3.yaml
@@ -13,7 +13,7 @@ info:
 
     ```
     curl
-    -U "ws@Company.YourCompany":"YourWsPassword" \
+    -u "ws@Company.YourCompany":"YourWsPassword" \
     -H "Content-Type: application/json" \
     ...
     ```

--- a/specs/3.0/AccountService-v4.yaml
+++ b/specs/3.0/AccountService-v4.yaml
@@ -13,7 +13,7 @@ info:
 
     ```
     curl
-    -U "ws@Company.YourCompany":"YourWsPassword" \
+    -u "ws@Company.YourCompany":"YourWsPassword" \
     -H "Content-Type: application/json" \
     ...
     ```

--- a/specs/3.0/FundService-v3.yaml
+++ b/specs/3.0/FundService-v3.yaml
@@ -13,7 +13,7 @@ info:
 
     ```
     curl
-    -U "ws@Company.YourCompany":"YourWsPassword" \
+    -u "ws@Company.YourCompany":"YourWsPassword" \
     -H "Content-Type: application/json" \
     ...
     ```

--- a/specs/3.0/NotificationConfigurationService-v1.yaml
+++ b/specs/3.0/NotificationConfigurationService-v1.yaml
@@ -13,7 +13,7 @@ info:
 
     ```
     curl
-    -U "ws@Company.YourCompany":"YourWsPassword" \
+    -u "ws@Company.YourCompany":"YourWsPassword" \
     -H "Content-Type: application/json" \
     ...
     ```

--- a/specs/3.0/PaymentService-V30.yaml
+++ b/specs/3.0/PaymentService-V30.yaml
@@ -14,7 +14,7 @@ info:
 
     ```
     curl
-    -U "ws@Company.YourCompany":"YourWsPassword" \
+    -u "ws@Company.YourCompany":"YourWsPassword" \
     -H "Content-Type: application/json" \
     ...
     ```


### PR DESCRIPTION
I was trying out the API using curl, but couldn't get it to work. Then I looked at the man pages for curl and saw that `-U` is the wrong flag to use. 

The curl flag `-U` is used for:

> Specify the user name and password to use for proxy authentication.

This curl flag `-u` is used for:

> Specify the user name and password to use for server authentication.

This change adds the correct curl flag for using basic
authentication.