### PR TITLE
Added correct schema to RecurringDetailsResult

### DIFF
--- a/json/RecurringService-v68.json
+++ b/json/RecurringService-v68.json
@@ -1164,6 +1164,14 @@
                "variant"
             ]
          },
+         "RecurringDetailContainer": {
+            "properties": {
+               "RecurringDetail": {
+                  "description": "Payment details stored for recurring payments",
+                  "$ref" : "#/components/schemas/RecurringDetail"
+               }
+            }
+         },
          "RecurringDetailsRequest" : {
             "properties" : {
                "merchantAccount" : {
@@ -1192,9 +1200,9 @@
                   "type" : "string"
                },
                "details" : {
-                  "description" : "Payment details stored for recurring payments.",
+                  "description" : "A container for payment details.",
                   "items" : {
-                     "$ref" : "#/components/schemas/RecurringDetail"
+                     "$ref" : "#/components/schemas/RecurringDetailContainer"
                   },
                   "type" : "array"
                },

--- a/yaml/RecurringService-v68.yaml
+++ b/yaml/RecurringService-v68.yaml
@@ -927,6 +927,11 @@ components:
       required:
       - recurringDetailReference
       - variant
+    RecurringDetailContainer:
+      properties:
+        RecurringDetail:
+          description: Payment details stored for recurring payments
+          $ref: '#/components/schemas/RecurringDetail'
     RecurringDetailsRequest:
       properties:
         merchantAccount:
@@ -959,9 +964,9 @@ components:
           format: date-time
           type: string
         details:
-          description: Payment details stored for recurring payments.
+          description: A container for payment details.
           items:
-            $ref: '#/components/schemas/RecurringDetail'
+            $ref: '#/components/schemas/RecurringDetailContainer'
           type: array
         lastKnownShopperEmail:
           description: The most recent email for this shopper (if available).


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Currently API response and OpenAPI schema do not match. I updated `RecurringDetailsResult` schema so that it represents the response from the API.

## Tested scenarios
I generated Postman collections from updated schemas and verified that `/listRecurringDetails` returns correct example data.
