### PR TITLE
Add trigger to notify.yml to call adyen-postman actions

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -15,3 +15,5 @@ jobs:
         run: gh workflow run models.yml -R Adyen/adyen-node-api-library
       - name: Java 
         run: gh workflow run models.yml -R Adyen/adyen-java-api-library
+      - name: Postman 
+        run: gh workflow run trigger-postman.yml -R Adyen/adyen-postman


### PR DESCRIPTION
This commit creates a new workflow that will trigger a github action on the [adyen-postman](https://github.com/Adyen/adyen-postman) repository every time a new commit is pushed to main on this repository. It is a necessary step to have postman definition files that are always up to date

See https://github.com/Adyen/adyen-openapi/pull/37 for first proposal