### PR TITLE
Remove ruby notify

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -31,8 +31,6 @@ jobs:
           gh workflow run services.yml -R Adyen/adyen-php-api-library
       - name: Python
         run: gh workflow run services.yml -R Adyen/adyen-python-api-library
-      - name: Ruby
-        run: gh workflow run services.yml -R Adyen/adyen-ruby-api-library
       - name: SDK Automation
         run: gh workflow run gradle.yml -R Adyen/adyen-sdk-automation
       - name: Postman 


### PR DESCRIPTION
## Summary
Remove ruby notify in favour of central automation

