### PR TITLE
Remove Dotnet-specific automation

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -19,10 +19,6 @@ jobs:
         run: |
             gh workflow run models.yml -R Adyen/adyen-java-api-library
             gh workflow run services.yml -R Adyen/adyen-java-api-library
-      - name: .NET 
-        run: |
-          gh workflow run models.yml -R Adyen/adyen-dotnet-api-library
-          gh workflow run services.yml -R Adyen/adyen-dotnet-api-library
       - name: Go
         run: gh workflow run models.yml -R Adyen/adyen-go-api-library
       - name: PHP models and services


### PR DESCRIPTION
## Summary
Remove Dotnet-specific automation. Central automation will be used going forward
