### PR TITLE
Improve Dispute webhooks

### DIFF
--- a/json/Webhooks-v1.json
+++ b/json/Webhooks-v1.json
@@ -514,6 +514,80 @@
             }
          }
       },
+      "/ISSUER_COMMENTS" : {
+         "post" : {
+            "tags" : [
+               "Dispute"
+            ],
+            "summary" : "Issuer included comments",
+            "description" : "The issuer included [free-text comments](https://docs.adyen.com/risk-management/disputes-api/dispute-notifications/issuer-comments) with relevant information about the dispute process, such as why the issuer decided to initiate or continue the dispute. You can receive issuer comments for chargebacks and pre-arbitration cases.",
+            "operationId" : "post-ISSUER_COMMENTS",
+            "x-sortIndex" : 0,
+            "x-methodName" : "issuerIncludedComments",
+            "security" : [
+               {
+                  "BasicAuth" : [
+                     ]
+               }
+            ],
+            "requestBody" : {
+               "content" : {
+                  "application/json" : {
+                     "examples" : {
+                        "issuer_comments" : {
+                           "$ref" : "#/components/examples/post-ISSUER_COMMENTS-issuer_comments"
+                        }
+                     },
+                     "schema" : {
+                        "$ref" : "#/components/schemas/IssuerCommentsNotificationRequest"
+                     }
+                  }
+               }
+            },
+            "responses" : {
+               "200" : {
+                  "description" : "No Content - webhook events are accepted on the basis of the HTTP status code."
+               }
+            }
+         }
+      },
+      "/ISSUER_RESPONSE_TIMEFRAME_EXPIRED" : {
+         "post" : {
+            "tags" : [
+               "Dispute"
+            ],
+            "summary" : "Issuer accepted defense or did not respond",
+            "description" : "The issuer accepted your [defense of the dispute](https://docs.adyen.com/risk-management/manage-disputes/#defending-disputes) or [did not respond in time](https://docs.adyen.com/risk-management/understanding-disputes/dispute-timeframes/).",
+            "operationId" : "post-ISSUER_RESPONSE_TIMEFRAME_EXPIRED",
+            "x-sortIndex" : 0,
+            "x-methodName" : "issuerAcceptedDefenseOrDidNotRespond",
+            "security" : [
+               {
+                  "BasicAuth" : [
+                     ]
+               }
+            ],
+            "requestBody" : {
+               "content" : {
+                  "application/json" : {
+                     "examples" : {
+                        "issuer_response_timeframe_expired" : {
+                           "$ref" : "#/components/examples/post-ISSUER_RESPONSE_TIMEFRAME_EXPIRED-issuer_response_timeframe_expired"
+                        }
+                     },
+                     "schema" : {
+                        "$ref" : "#/components/schemas/IssuerResponseTimeframeExpiredNotificationRequest"
+                     }
+                  }
+               }
+            },
+            "responses" : {
+               "200" : {
+                  "description" : "No Content - webhook events are accepted on the basis of the HTTP status code."
+               }
+            }
+         }
+      },
       "/MANUAL_REVIEW_ACCEPT" : {
          "post" : {
             "tags" : [
@@ -1621,7 +1695,7 @@
                      "CHARGEBACK",
                      "CHARGEBACK_REVERSED",
                      "DISPUTE_DEFENSE_PERIOD_ENDED",
-                     "EXPIRED",
+                     "EXPIRE",
                      "HANDLED_EXTERNALLY",
                      "INFORMATION_SUPPLIED",
                      "ISSUER_COMMENTS",
@@ -1717,7 +1791,7 @@
                      "CHARGEBACK",
                      "CHARGEBACK_REVERSED",
                      "DISPUTE_DEFENSE_PERIOD_ENDED",
-                     "EXPIRED",
+                     "EXPIRE",
                      "HANDLED_EXTERNALLY",
                      "INFORMATION_SUPPLIED",
                      "ISSUER_COMMENTS",
@@ -2808,7 +2882,7 @@
                      "CHARGEBACK",
                      "CHARGEBACK_REVERSED",
                      "DISPUTE_DEFENSE_PERIOD_ENDED",
-                     "EXPIRED",
+                     "EXPIRE",
                      "HANDLED_EXTERNALLY",
                      "INFORMATION_SUPPLIED",
                      "ISSUER_COMMENTS",
@@ -2904,7 +2978,7 @@
                      "CHARGEBACK",
                      "CHARGEBACK_REVERSED",
                      "DISPUTE_DEFENSE_PERIOD_ENDED",
-                     "EXPIRED",
+                     "EXPIRE",
                      "HANDLED_EXTERNALLY",
                      "INFORMATION_SUPPLIED",
                      "ISSUER_COMMENTS",
@@ -3121,7 +3195,7 @@
                      "CHARGEBACK",
                      "CHARGEBACK_REVERSED",
                      "DISPUTE_DEFENSE_PERIOD_ENDED",
-                     "EXPIRED",
+                     "EXPIRE",
                      "HANDLED_EXTERNALLY",
                      "INFORMATION_SUPPLIED",
                      "ISSUER_COMMENTS",
@@ -3217,7 +3291,7 @@
                      "CHARGEBACK",
                      "CHARGEBACK_REVERSED",
                      "DISPUTE_DEFENSE_PERIOD_ENDED",
-                     "EXPIRED",
+                     "EXPIRE",
                      "HANDLED_EXTERNALLY",
                      "INFORMATION_SUPPLIED",
                      "ISSUER_COMMENTS",
@@ -3551,7 +3625,7 @@
                      "CHARGEBACK",
                      "CHARGEBACK_REVERSED",
                      "DISPUTE_DEFENSE_PERIOD_ENDED",
-                     "EXPIRED",
+                     "EXPIRE",
                      "HANDLED_EXTERNALLY",
                      "INFORMATION_SUPPLIED",
                      "ISSUER_COMMENTS",
@@ -3647,7 +3721,7 @@
                      "CHARGEBACK",
                      "CHARGEBACK_REVERSED",
                      "DISPUTE_DEFENSE_PERIOD_ENDED",
-                     "EXPIRED",
+                     "EXPIRE",
                      "HANDLED_EXTERNALLY",
                      "INFORMATION_SUPPLIED",
                      "ISSUER_COMMENTS",
@@ -3838,7 +3912,7 @@
                      "CHARGEBACK",
                      "CHARGEBACK_REVERSED",
                      "DISPUTE_DEFENSE_PERIOD_ENDED",
-                     "EXPIRED",
+                     "EXPIRE",
                      "HANDLED_EXTERNALLY",
                      "INFORMATION_SUPPLIED",
                      "ISSUER_COMMENTS",
@@ -3934,7 +4008,7 @@
                      "CHARGEBACK",
                      "CHARGEBACK_REVERSED",
                      "DISPUTE_DEFENSE_PERIOD_ENDED",
-                     "EXPIRED",
+                     "EXPIRE",
                      "HANDLED_EXTERNALLY",
                      "INFORMATION_SUPPLIED",
                      "ISSUER_COMMENTS",
@@ -4296,7 +4370,7 @@
                      "CHARGEBACK",
                      "CHARGEBACK_REVERSED",
                      "DISPUTE_DEFENSE_PERIOD_ENDED",
-                     "EXPIRED",
+                     "EXPIRE",
                      "HANDLED_EXTERNALLY",
                      "INFORMATION_SUPPLIED",
                      "ISSUER_COMMENTS",
@@ -4392,7 +4466,7 @@
                      "CHARGEBACK",
                      "CHARGEBACK_REVERSED",
                      "DISPUTE_DEFENSE_PERIOD_ENDED",
-                     "EXPIRED",
+                     "EXPIRE",
                      "HANDLED_EXTERNALLY",
                      "INFORMATION_SUPPLIED",
                      "ISSUER_COMMENTS",
@@ -4665,7 +4739,7 @@
                      "CHARGEBACK",
                      "CHARGEBACK_REVERSED",
                      "DISPUTE_DEFENSE_PERIOD_ENDED",
-                     "EXPIRED",
+                     "EXPIRE",
                      "HANDLED_EXTERNALLY",
                      "INFORMATION_SUPPLIED",
                      "ISSUER_COMMENTS",
@@ -4761,7 +4835,7 @@
                      "CHARGEBACK",
                      "CHARGEBACK_REVERSED",
                      "DISPUTE_DEFENSE_PERIOD_ENDED",
-                     "EXPIRED",
+                     "EXPIRE",
                      "HANDLED_EXTERNALLY",
                      "INFORMATION_SUPPLIED",
                      "ISSUER_COMMENTS",
@@ -4850,6 +4924,446 @@
                }
             }
          },
+         "IssuerCommentsNotificationAdditionalData" : {
+            "additionalProperties" : false,
+            "properties" : {
+               "InvoiceCreditorAccount" : {
+                  "type" : "string"
+               },
+               "arn" : {
+                  "description" : "Acquirer Reference Number of the dispute.",
+                  "type" : "string"
+               },
+               "autoDefended" : {
+                  "description" : "Indicates if the dispute was automatically defended.",
+                  "type" : "string"
+               },
+               "captureMerchantReference" : {
+                  "description" : "The merchant reference of the capture.",
+                  "type" : "string"
+               },
+               "capturePspReference" : {
+                  "description" : "The PSP reference of the capture.",
+                  "type" : "string"
+               },
+               "chargebackReasonCode" : {
+                  "description" : "The [reason code](https://docs.adyen.com/risk-management/understanding-disputes/dispute-reason-codes/?tab=chargeback_0_1) for the chargeback.",
+                  "type" : "string"
+               },
+               "chargebackSchemeCode" : {
+                  "description" : "The card scheme for the chargeback.",
+                  "type" : "string"
+               },
+               "defendable" : {
+                  "description" : "Indicates if you can defend the dispute.",
+                  "type" : "string"
+               },
+               "defensePeriodEndsAt" : {
+                  "description" : "When the defense period ends. Format: [ISO 8601](https://www.w3.org/TR/NOTE-datetime) format with time zone offset: YYYY-MM-DDThh:mm:ss+TZD, for example, **2020-12-18T10:15:30+01:00**.",
+                  "format" : "date-time",
+                  "type" : "string"
+               },
+               "disputeStatus" : {
+                  "description" : "More information about the [stage the dispute is in](https://docs.adyen.com/risk-management/disputes-api/dispute-notifications/). This parameter is not returned for disputed payments processed in Brazil.",
+                  "enum" : [
+                     "Unresponded",
+                     "Responded",
+                     "Expired",
+                     "Undefended",
+                     "Accepted",
+                     "Pending",
+                     "Lost",
+                     "Won"
+                  ],
+                  "type" : "string"
+               },
+               "grossCurrency" : {
+                  "description" : "Chargeback gross currency.",
+                  "type" : "string"
+               },
+               "grossValue" : {
+                  "description" : "Chargeback gross value.",
+                  "type" : "string"
+               },
+               "hmacSignature" : {
+                  "type" : "string"
+               },
+               "issuerComments.attemptedReturnDate" : {
+                  "type" : "string"
+               },
+               "issuerComments.cancellationDate" : {
+                  "format" : "date-time",
+                  "type" : "string"
+               },
+               "issuerComments.cancellationMethod" : {
+                  "type" : "string"
+               },
+               "issuerComments.chReceivedOrExpectedMerchandise" : {
+                  "type" : "string"
+               },
+               "issuerComments.creditVoucherOrTransactionReceiptDate" : {
+                  "type" : "string"
+               },
+               "issuerComments.damagedOrDefectiveOrderInfo" : {
+                  "type" : "string"
+               },
+               "issuerComments.dateOfService" : {
+                  "format" : "date-time",
+                  "type" : "string"
+               },
+               "issuerComments.descCounterfeitMerchandise" : {
+                  "type" : "string"
+               },
+               "issuerComments.disputeAmountChangeReason" : {
+                  "type" : "string"
+               },
+               "issuerComments.expectedReceiptDateTime" : {
+                  "format" : "date-time",
+                  "type" : "string"
+               },
+               "issuerComments.explanation" : {
+                  "type" : "string"
+               },
+               "issuerComments.explanationOfCreditPresented" : {
+                  "type" : "string"
+               },
+               "issuerComments.howChAttemptReturnAndDispOfMerchandise" : {
+                  "type" : "string"
+               },
+               "issuerComments.howMerchandiseOrServiceMisrepresented" : {
+                  "type" : "string"
+               },
+               "issuerComments.howTermsOfContractNotHonoredByMerchant" : {
+                  "type" : "string"
+               },
+               "issuerComments.infoMerchandiseToBeCounterfeit" : {
+                  "type" : "string"
+               },
+               "issuerComments.merchandiseOrServices" : {
+                  "type" : "string"
+               },
+               "issuerComments.merchandiseServiceReceivedDate" : {
+                  "format" : "date-time",
+                  "type" : "string"
+               },
+               "issuerComments.merchandiseWasCounterfeitDate" : {
+                  "format" : "date-time",
+                  "type" : "string"
+               },
+               "issuerComments.note" : {
+                  "type" : "string"
+               },
+               "issuerComments.orderDetailsNotAsDescribed" : {
+                  "type" : "string"
+               },
+               "issuerComments.purchasedInfo" : {
+                  "type" : "string"
+               },
+               "issuerComments.purchasedInfoAndQualityIssue" : {
+                  "type" : "string"
+               },
+               "issuerComments.returnMethod" : {
+                  "type" : "string"
+               },
+               "issuerComments.returnedMerchandiseReceivedDate" : {
+                  "format" : "date-time",
+                  "type" : "string"
+               },
+               "issuerComments.serviceReceivedDate" : {
+                  "format" : "date-time",
+                  "type" : "string"
+               },
+               "issuerComments.type" : {
+                  "type" : "string"
+               },
+               "issuerComments.whatWasOrdered" : {
+                  "type" : "string"
+               },
+               "issuerComments.whatWasPurchased" : {
+                  "type" : "string"
+               },
+               "issuerComments.whereIsMerchandiseLocated" : {
+                  "type" : "string"
+               },
+               "modificationMerchantReferences" : {
+                  "type" : "string"
+               },
+               "nofReasonCode" : {
+                  "description" : "The [reason code](https://docs.adyen.com/risk-management/understanding-disputes/dispute-reason-codes/?tab=notification_of_fraud_2_3) for the Notification of Fraud (NOF).",
+                  "type" : "string"
+               },
+               "nofSchemeCode" : {
+                  "description" : "The card scheme for the Notification of Fraud (NOF).",
+                  "type" : "string"
+               },
+               "paymentMethodVariant" : {
+                  "description" : "The Adyen [sub-variant of the payment method](https://docs.adyen.com/development-resources/paymentmethodvariant) used for the payment request.",
+                  "type" : "string"
+               },
+               "rfiReasonCode" : {
+                  "description" : "The [reason code](https://docs.adyen.com/risk-management/understanding-disputes/dispute-reason-codes/?tab=request_for_information_1_2) for the Request for Information (RFI).",
+                  "type" : "string"
+               },
+               "rfiSchemeCode" : {
+                  "description" : "The card scheme for the Request for Information (RFI).",
+                  "type" : "string"
+               },
+               "shopperReference" : {
+                  "description" : "The ID that uniquely identifies the shopper. This is the same as the `shopperReference` used in the initial payment.",
+                  "type" : "string"
+               }
+            },
+            "type" : "object"
+         },
+         "IssuerCommentsNotificationRequest" : {
+            "additionalProperties" : false,
+            "properties" : {
+               "live" : {
+                  "description" : "Informs about the origin of the notification. The value is **true** when originating from the live environment, **false** for the test environment.",
+                  "type" : "string"
+               },
+               "notificationItems" : {
+                  "description" : "A container object for the details included in the notification.",
+                  "items" : {
+                     "$ref" : "#/components/schemas/IssuerCommentsNotificationRequestItemWrapper"
+                  },
+                  "type" : "array"
+               }
+            },
+            "type" : "object"
+         },
+         "IssuerCommentsNotificationRequestItem" : {
+            "additionalProperties" : false,
+            "properties" : {
+               "additionalData" : {
+                  "description" : "This object is a generic container that can hold extra fields.",
+                  "$ref" : "#/components/schemas/IssuerCommentsNotificationAdditionalData"
+               },
+               "amount" : {
+                  "description" : "The payment amount. For HTTP POST notifications, currency and value are returned as URL parameters.",
+                  "$ref" : "#/components/schemas/Amount"
+               },
+               "eventCode" : {
+                  "description" : "The type of event the notification item is for.",
+                  "enum" : [
+                     "AUTHENTICATION",
+                     "AUTHORISATION",
+                     "AUTHORISATION_ADJUSTMENT",
+                     "AUTORESCUE",
+                     "CANCELLATION",
+                     "CANCEL_AUTORESCUE",
+                     "CANCEL_OR_REFUND",
+                     "CAPTURE",
+                     "CAPTURE_FAILED",
+                     "CHARGEBACK",
+                     "CHARGEBACK_REVERSED",
+                     "DISPUTE_DEFENSE_PERIOD_ENDED",
+                     "EXPIRE",
+                     "HANDLED_EXTERNALLY",
+                     "INFORMATION_SUPPLIED",
+                     "ISSUER_COMMENTS",
+                     "ISSUER_RESPONSE_TIMEFRAME_EXPIRED",
+                     "MANUAL_REVIEW_ACCEPT",
+                     "MANUAL_REVIEW_REJECT",
+                     "NOTIFICATION_OF_CHARGEBACK",
+                     "NOTIFICATION_OF_FRAUD",
+                     "OFFER_CLOSED",
+                     "ORDER_CLOSED",
+                     "ORDER_OPENED",
+                     "PAYOUT_DECLINE",
+                     "PAYOUT_EXPIRE",
+                     "PAYOUT_THIRDPARTY",
+                     "POSTPONED_REFUND",
+                     "PREARBITRATION_LOST",
+                     "PREARBITRATION_OPEN",
+                     "PREARBITRATION_WON",
+                     "RECURRING_CONTRACT",
+                     "REFUND",
+                     "REFUNDED_REVERSED",
+                     "REFUND_FAILED",
+                     "REFUND_WITH_DATA",
+                     "REQUEST_FOR_INFORMATION",
+                     "SECOND_CHARGEBACK",
+                     "TECHNICAL_CANCEL",
+                     "VOID_PENDING_REFUND"
+                  ],
+                  "type" : "string"
+               },
+               "eventDate" : {
+                  "description" : "The time when the event was generated. Format: ISO 8601; yyyy-MM-DDThh:mm:ssTZD",
+                  "example" : "2021-07-17T13:42:40+01:00",
+                  "format" : "date-time",
+                  "type" : "string"
+               },
+               "merchantAccountCode" : {
+                  "description" : "The merchant account identifier used in the transaction the notification item is for.",
+                  "type" : "string"
+               },
+               "merchantReference" : {
+                  "description" : "Your reference to uniquely identify the payment.",
+                  "type" : "string"
+               },
+               "originalReference" : {
+                  "description" : "For modifications, this field corresponds to the payment request assigned to the original payment.",
+                  "type" : "string"
+               },
+               "paymentMethod" : {
+                  "description" : "The payment method used in the transaction.",
+                  "example" : "visa, mc, iDeal",
+                  "type" : "string"
+               },
+               "pspReference" : {
+                  "description" : "Adyen's 16-character unique reference associated with the transaction or request. This value is globally unique. Use it when communicating with us about this request.",
+                  "type" : "string"
+               },
+               "reason" : {
+                  "description" : "If `success` = `false`, then this includes a short message with an explanation for the refusal.",
+                  "type" : "string"
+               },
+               "success" : {
+                  "description" : "Informs about the outcome of the event (`eventCode`) the notification is for. \nIf `true`: the event was executed successfully. \nIf `false`: the event was not executed successfully.",
+                  "type" : "string"
+               }
+            },
+            "required" : [
+               "pspReference",
+               "merchantReference",
+               "merchantAccountCode",
+               "eventDate",
+               "eventCode",
+               "amount",
+               "success"
+            ],
+            "type" : "object"
+         },
+         "IssuerCommentsNotificationRequestItem-recursive" : {
+            "additionalProperties" : false,
+            "properties" : {
+               "eventCode" : {
+                  "description" : "The type of event the notification item is for.",
+                  "enum" : [
+                     "AUTHENTICATION",
+                     "AUTHORISATION",
+                     "AUTHORISATION_ADJUSTMENT",
+                     "AUTORESCUE",
+                     "CANCELLATION",
+                     "CANCEL_AUTORESCUE",
+                     "CANCEL_OR_REFUND",
+                     "CAPTURE",
+                     "CAPTURE_FAILED",
+                     "CHARGEBACK",
+                     "CHARGEBACK_REVERSED",
+                     "DISPUTE_DEFENSE_PERIOD_ENDED",
+                     "EXPIRE",
+                     "HANDLED_EXTERNALLY",
+                     "INFORMATION_SUPPLIED",
+                     "ISSUER_COMMENTS",
+                     "ISSUER_RESPONSE_TIMEFRAME_EXPIRED",
+                     "MANUAL_REVIEW_ACCEPT",
+                     "MANUAL_REVIEW_REJECT",
+                     "NOTIFICATION_OF_CHARGEBACK",
+                     "NOTIFICATION_OF_FRAUD",
+                     "OFFER_CLOSED",
+                     "ORDER_CLOSED",
+                     "ORDER_OPENED",
+                     "PAYOUT_DECLINE",
+                     "PAYOUT_EXPIRE",
+                     "PAYOUT_THIRDPARTY",
+                     "POSTPONED_REFUND",
+                     "PREARBITRATION_LOST",
+                     "PREARBITRATION_OPEN",
+                     "PREARBITRATION_WON",
+                     "RECURRING_CONTRACT",
+                     "REFUND",
+                     "REFUNDED_REVERSED",
+                     "REFUND_FAILED",
+                     "REFUND_WITH_DATA",
+                     "REQUEST_FOR_INFORMATION",
+                     "SECOND_CHARGEBACK",
+                     "TECHNICAL_CANCEL",
+                     "VOID_PENDING_REFUND"
+                  ],
+                  "type" : "string"
+               },
+               "merchantAccountCode" : {
+                  "description" : "The merchant account identifier used in the transaction the notification item is for.",
+                  "type" : "string"
+               },
+               "originalReference" : {
+                  "description" : "For modifications, this field corresponds to the payment request assigned to the original payment.",
+                  "type" : "string"
+               },
+               "reason" : {
+                  "description" : "If `success` = `false`, then this includes a short message with an explanation for the refusal.",
+                  "type" : "string"
+               },
+               "amount" : {
+                  "description" : "The payment amount. For HTTP POST notifications, currency and value are returned as URL parameters.",
+                  "$ref" : "#/components/schemas/Amount"
+               },
+               "success" : {
+                  "description" : "Informs about the outcome of the event (`eventCode`) the notification is for. \nIf `true`: the event was executed successfully. \nIf `false`: the event was not executed successfully.",
+                  "type" : "string"
+               },
+               "paymentMethod" : {
+                  "description" : "The payment method used in the transaction.",
+                  "example" : "visa, mc, iDeal",
+                  "type" : "string"
+               },
+               "additionalData" : {
+                  "description" : "This object is a generic container that can hold extra fields.",
+                  "$ref" : "#/components/schemas/IssuerCommentsNotificationAdditionalData"
+               },
+               "merchantReference" : {
+                  "description" : "Your reference to uniquely identify the payment.",
+                  "type" : "string"
+               },
+               "pspReference" : {
+                  "description" : "Adyen's 16-character unique reference associated with the transaction or request. This value is globally unique. Use it when communicating with us about this request.",
+                  "type" : "string"
+               },
+               "eventDate" : {
+                  "description" : "The time when the event was generated. Format: ISO 8601; yyyy-MM-DDThh:mm:ssTZD",
+                  "example" : "2021-07-17T13:42:40+01:00",
+                  "format" : "date-time",
+                  "type" : "string"
+               }
+            },
+            "required" : [
+               "pspReference",
+               "merchantReference",
+               "merchantAccountCode",
+               "eventDate",
+               "eventCode",
+               "amount",
+               "success"
+            ],
+            "type" : "object"
+         },
+         "IssuerCommentsNotificationRequestItemWrapper" : {
+            "properties" : {
+               "NotificationRequestItem" : {
+                  "$ref" : "#/components/schemas/IssuerCommentsNotificationRequestItem"
+               }
+            }
+         },
+         "IssuerResponseTimeframeExpiredNotificationRequest" : {
+            "additionalProperties" : false,
+            "properties" : {
+               "live" : {
+                  "description" : "Informs about the origin of the notification. The value is **true** when originating from the live environment, **false** for the test environment.",
+                  "type" : "string"
+               },
+               "notificationItems" : {
+                  "description" : "A container object for the details included in the notification.",
+                  "items" : {
+                     "$ref" : "#/components/schemas/IssuerCommentsNotificationRequestItemWrapper"
+                  },
+                  "type" : "array"
+               }
+            },
+            "type" : "object"
+         },
          "ModificationNotificationRequest" : {
             "additionalProperties" : false,
             "properties" : {
@@ -4893,7 +5407,7 @@
                      "CHARGEBACK",
                      "CHARGEBACK_REVERSED",
                      "DISPUTE_DEFENSE_PERIOD_ENDED",
-                     "EXPIRED",
+                     "EXPIRE",
                      "HANDLED_EXTERNALLY",
                      "INFORMATION_SUPPLIED",
                      "ISSUER_COMMENTS",
@@ -4989,7 +5503,7 @@
                      "CHARGEBACK",
                      "CHARGEBACK_REVERSED",
                      "DISPUTE_DEFENSE_PERIOD_ENDED",
-                     "EXPIRED",
+                     "EXPIRE",
                      "HANDLED_EXTERNALLY",
                      "INFORMATION_SUPPLIED",
                      "ISSUER_COMMENTS",
@@ -5652,7 +6166,7 @@
                      "CHARGEBACK",
                      "CHARGEBACK_REVERSED",
                      "DISPUTE_DEFENSE_PERIOD_ENDED",
-                     "EXPIRED",
+                     "EXPIRE",
                      "HANDLED_EXTERNALLY",
                      "INFORMATION_SUPPLIED",
                      "ISSUER_COMMENTS",
@@ -5748,7 +6262,7 @@
                      "CHARGEBACK",
                      "CHARGEBACK_REVERSED",
                      "DISPUTE_DEFENSE_PERIOD_ENDED",
-                     "EXPIRED",
+                     "EXPIRE",
                      "HANDLED_EXTERNALLY",
                      "INFORMATION_SUPPLIED",
                      "ISSUER_COMMENTS",
@@ -6071,7 +6585,7 @@
                      "CHARGEBACK",
                      "CHARGEBACK_REVERSED",
                      "DISPUTE_DEFENSE_PERIOD_ENDED",
-                     "EXPIRED",
+                     "EXPIRE",
                      "HANDLED_EXTERNALLY",
                      "INFORMATION_SUPPLIED",
                      "ISSUER_COMMENTS",
@@ -6167,7 +6681,7 @@
                      "CHARGEBACK",
                      "CHARGEBACK_REVERSED",
                      "DISPUTE_DEFENSE_PERIOD_ENDED",
-                     "EXPIRED",
+                     "EXPIRE",
                      "HANDLED_EXTERNALLY",
                      "INFORMATION_SUPPLIED",
                      "ISSUER_COMMENTS",
@@ -7076,7 +7590,7 @@
                      "CHARGEBACK",
                      "CHARGEBACK_REVERSED",
                      "DISPUTE_DEFENSE_PERIOD_ENDED",
-                     "EXPIRED",
+                     "EXPIRE",
                      "HANDLED_EXTERNALLY",
                      "INFORMATION_SUPPLIED",
                      "ISSUER_COMMENTS",
@@ -7172,7 +7686,7 @@
                      "CHARGEBACK",
                      "CHARGEBACK_REVERSED",
                      "DISPUTE_DEFENSE_PERIOD_ENDED",
-                     "EXPIRED",
+                     "EXPIRE",
                      "HANDLED_EXTERNALLY",
                      "INFORMATION_SUPPLIED",
                      "ISSUER_COMMENTS",
@@ -7332,7 +7846,7 @@
                      "CHARGEBACK",
                      "CHARGEBACK_REVERSED",
                      "DISPUTE_DEFENSE_PERIOD_ENDED",
-                     "EXPIRED",
+                     "EXPIRE",
                      "HANDLED_EXTERNALLY",
                      "INFORMATION_SUPPLIED",
                      "ISSUER_COMMENTS",
@@ -7428,7 +7942,7 @@
                      "CHARGEBACK",
                      "CHARGEBACK_REVERSED",
                      "DISPUTE_DEFENSE_PERIOD_ENDED",
-                     "EXPIRED",
+                     "EXPIRE",
                      "HANDLED_EXTERNALLY",
                      "INFORMATION_SUPPLIED",
                      "ISSUER_COMMENTS",
@@ -7717,7 +8231,7 @@
                      "CHARGEBACK",
                      "CHARGEBACK_REVERSED",
                      "DISPUTE_DEFENSE_PERIOD_ENDED",
-                     "EXPIRED",
+                     "EXPIRE",
                      "HANDLED_EXTERNALLY",
                      "INFORMATION_SUPPLIED",
                      "ISSUER_COMMENTS",
@@ -7813,7 +8327,7 @@
                      "CHARGEBACK",
                      "CHARGEBACK_REVERSED",
                      "DISPUTE_DEFENSE_PERIOD_ENDED",
-                     "EXPIRED",
+                     "EXPIRE",
                      "HANDLED_EXTERNALLY",
                      "INFORMATION_SUPPLIED",
                      "ISSUER_COMMENTS",
@@ -8475,6 +8989,75 @@
                         "merchantReference" : "YOUR_MERCHANT_REFERENCE",
                         "pspReference" : "QFQTPCQ8HXSKGK82",
                         "reason" : "",
+                        "success" : "true"
+                     }
+                  }
+               ]
+            }
+         },
+         "post-ISSUER_COMMENTS-issuer_comments" : {
+            "summary" : "ISSUER_COMMENTS example",
+            "value" : {
+               "live" : "false",
+               "notificationItems" : [
+                  {
+                     "NotificationRequestItem" : {
+                        "additionalData" : {
+                           "chargebackReasonCode" : "13.3",
+                           "chargebackSchemeCode" : "visa",
+                           "issuerComments.type" : "chargeback",
+                           "issuerComments.disputeAmountChangeReason" : "some_text",
+                           "issuerComments.cancellationMethod" : "some_text",
+                           "issuerComments.orderDetailsNotAsDescribed" : "some_text",
+                           "issuerComments.explanation" : "some_text",
+                           "issuerComments.damagedOrDefectiveOrderInfo" : "some_text",
+                           "issuerComments.howChAttemptReturnAndDispOfMerchandise" : "some_text",
+                           "issuerComments.whatWasNotReceived" : "some_text",
+                           "issuerComments.cancellationDate" : "some_text"
+                        },
+                        "amount" : {
+                           "currency" : "EUR",
+                           "value" : 1000
+                        },
+                        "eventCode" : "ISSUER_COMMENTS",
+                        "eventDate" : "2021-05-17T09:35:14+02:00",
+                        "merchantAccountCode" : "ADYEN_MERCHANT_ACCOUNT",
+                        "originalReference" : "9914444444444444",
+                        "merchantReference" : "YOUR_REFERENCE",
+                        "paymentMethod" : "visa",
+                        "pspReference" : "9915555555555555",
+                        "reason" : "Not as Described or Defective Merchandise/Services",
+                        "success" : "true"
+                     }
+                  }
+               ]
+            }
+         },
+         "post-ISSUER_RESPONSE_TIMEFRAME_EXPIRED-issuer_response_timeframe_expired" : {
+            "summary" : "ISSUER_RESPONSE_TIMEFRAME_EXPIRED example",
+            "value" : {
+               "live" : "false",
+               "notificationItems" : [
+                  {
+                     "NotificationRequestItem" : {
+                        "additionalData" : {
+                           "chargebackReasonCode" : "13.1",
+                           "chargebackSchemeCode" : "visa",
+                           "modificationMerchantReferences" : "",
+                           "disputeStatus" : "Won"
+                        },
+                        "amount" : {
+                           "currency" : "USD",
+                           "value" : 10000
+                        },
+                        "eventCode" : "ISSUER_RESPONSE_TIMEFRAME_EXPIRED",
+                        "eventDate" : "2021-05-19T09:35:14+02:00",
+                        "merchantAccountCode" : "ADYEN_MERCHANT_ACCOUNT",
+                        "originalReference" : "9914444444444444",
+                        "merchantReference" : "YOUR_REFERENCE",
+                        "paymentMethod" : "visa",
+                        "pspReference" : "9915555555555555",
+                        "reason" : "Merchandise/Services Not Received",
                         "success" : "true"
                      }
                   }


### PR DESCRIPTION
Proposed new version of `Webhooks-v1.json`

Update `CHARGEBACK`, `NOTIFICATION_OF_CHARGEBACK`, `PREARBITRATION_LOST`, `PREARBITRATION_OPEN`, `PREARBITRATION_WON`, `CHARGEBACK_REVERSED`, `REQUEST_FOR_INFORMATION`, `SECOND_CHARGEBACK` to use dedicated models.
All Disputes-related models share `DisputesNotificationAdditionalData`: this includes `disputeStatus` enum, `chargebackReasonCode`, `chargebackSchemeCode`, `defendable`, etc..

Missing event codes have been included: `DISPUTE_DEFENSE_PERIOD_ENDED`, `EXPIRED`, `HANDLED_EXTERNALLY`, etc..
 